### PR TITLE
Added ability to handle a game restart

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Should only be used for earning Credits on RipperStore
 
 If you encounter any issues, please contact me via Discord. CodeAngel#5295
 
+Just a slight bugfix in the form of a PR, currently if the game is restarted by another mod, this restart will fail because the external application is not closed causing the mod to be broken upon restart. I fixed this by making the mod attemt to close the external application on run.
+
 [Download Latest Version](https://github.com/CodeAngel3/RipperStoreCredits/releases/download/9.0-beta/RipperStoreCredits.dll)
 
 [![Github All Releases](https://img.shields.io/github/downloads/CodeAngel3/RipperStoreCredits/total.svg)]()

--- a/RipperStoreInternal/Main.cs
+++ b/RipperStoreInternal/Main.cs
@@ -18,7 +18,7 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 
 [assembly: MelonGame("VRChat", "VRChat")]
-[assembly: MelonInfo(typeof(Ripper.Store.Internal.Main), "RipperStoreCredits", "9", "KeafyIsHere & CodeAngel")]
+[assembly: MelonInfo(typeof(Ripper.Store.Internal.Main), "RipperStoreCredits", "10", "KeafyIsHere, CodeAngel & LargestBoi")]
 
 namespace Ripper.Store.Internal
 {
@@ -31,6 +31,10 @@ namespace Ripper.Store.Internal
         private static HarmonyMethod GetPatch(string name) { return new HarmonyMethod(typeof(Main).GetMethod(name, BindingFlags.Static | BindingFlags.NonPublic)); }
         public override void OnApplicationStart()
         {
+			foreach (var process in Process.GetProcessesByName("RipperStoreExternal"))
+            {
+                process.Kill();
+            }
             File.WriteAllBytes("RipperStoreExternal.exe", Properties.Resources.RipperStore_External);
 
             ProcessStartInfo startInfo = new ProcessStartInfo()


### PR DESCRIPTION
Having the game restart via a 3rd party mod will end up having the ripper store external process remain open. This disallows the ripper store credits system from working within this new game instance while also leaving the second/old terminal window open. I just added a small check to attempt to close any applications with the name RipperStoreExternal before attempting to write to/run the program.